### PR TITLE
fix #275

### DIFF
--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,0 +1,50 @@
+# This is an example Mocha config containing every Mocha option plus others
+allow-uncaught: false
+async-only: false
+bail: false
+check-leaks: false
+color: true
+delay: false
+diff: true
+exit: false # could be expressed as "no-exit: true"
+extension:
+  - 'js'
+# fgrep and grep are mutually exclusive
+# fgrep: something
+#file:
+#  - '/path/to/some/file'
+#  - '/path/to/some/other/file'
+forbid-only: false
+forbid-pending: false
+full-trace: true
+#global:
+# - 'jQuery'
+#  - '$'
+# fgrep and grep are mutually exclusive
+# grep: something
+growl: false
+#ignore:
+#  - '/path/to/some/ignored/file'
+inline-diffs: false
+# needs to be used with grep or fgrep
+# invert: false
+recursive: false
+reporter: 'spec'
+#reporter-option:
+#  - 'foo=bar'
+#  - 'baz=quux'
+require: 'source-map-support/register'
+retries: 1
+slow: 75
+sort: false
+#spec: 'test/**/*.spec.js' # the positional arguments!
+timeout: false # same as "no-timeout: true" or "timeout: 0"
+trace-warnings: true # node flags ok
+ui: 'bdd'
+v8-stack-trace-limit: 100 # V8 flags are prepended with "v8-"
+watch: false
+#watch-files:
+#  - 'lib/**/*.js'
+#  - 'test/**/*.js'
+#watch-ignore:
+#  - 'lib/vendor'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,12 @@
 
 environment:
   matrix:
-    - nodejs_version: "8"
-    - nodejs_version: "9"
     - nodejs_version: "10"
     - nodejs_version: "11"
+    - nodejs_version: "12"
+    - nodejs_version: "13"
+    - nodejs_version: "14"
+    - nodejs_version: "15"
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -22,15 +22,15 @@
   "homepage": "https://www.testdeck.org/",
   "dependencies": {},
   "devDependencies": {
-    "@types/chai": "*",
-    "@types/mocha": "*",
-    "@testdeck/mocha": "*",
-    "chai": "*",
-    "mocha": "*",
-    "nyc": "*",
-    "source-map-support": "*",
-    "tslint": "*",
-    "typescript": "*"
+    "@types/chai": "latest",
+    "@types/mocha": "latest",
+    "@testdeck/mocha": "latest",
+    "chai": "latest",
+    "mocha": "latest",
+    "nyc": "latest",
+    "source-map-support": "latest",
+    "tslint": "latest",
+    "typescript": "latest"
   },
   "nyc": {
     "check-coverage": true,

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,0 @@
---require source-map-support/register
---recursive test


### PR DESCRIPTION
- mocha.opts was deprecated, replace with sample .mocharc.yaml
- use latest instead of asterisk as the version for all dependencies

see https://github.com/testdeck/testdeck/issues/275